### PR TITLE
Update Makefile to fix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,15 +14,17 @@ init:
 
 impulse: init module.o impulse.o
 	cp impulse.py $(BUILD_DIR)/impulse
-	gcc -pthread -shared -Wl,-O2 -Bsymbolic-functions -lfftw3 -lpulse\
+	gcc -pthread -shared -Wl,-O2 -Bsymbolic-functions\
 		-L$(BUILD_DIR)/impulse/ $(BUILD_DIR)/impulse/module.o\
-		$(BUILD_DIR)/impulse/impulse.o -o $(BUILD_DIR)/impulse/impulse.so
+		$(BUILD_DIR)/impulse/impulse.o -o $(BUILD_DIR)/impulse/impulse.so\
+		-lfftw3 -lpulse
 
 test: impulse.o
 	gcc -c src/test-impulse.c -o $(BUILD_DIR)/test/test-impulse.o
-	gcc -L$(BUILD_DIR)/test/ -lfftw3 -lpulse\
+	gcc -L$(BUILD_DIR)/test/\
 		$(BUILD_DIR)/impulse/impulse.o $(BUILD_DIR)/test/test-impulse.o\
-		-o $(BUILD_DIR)/test/test-impulse -lm
+		-o $(BUILD_DIR)/test/test-impulse -lm\
+		-lfftw3 -lpulse
 
 impulse.o:
 	gcc -pthread -Wall -fPIC -c src/impulse.c -o $(BUILD_DIR)/impulse/impulse.o


### PR DESCRIPTION
On Ubuntu 14.04 with gcc 4.8.4, the FFTw3 and Pulse libraries must be specified at the end, rather than beginning.
Otherwise, the compiled library and test-impulse program do not have the proper references.
For more information, see [GCC C++ Linker errors: Undefined reference to ...](http://stackoverflow.com/a/1095321)
